### PR TITLE
Fix argument handling in common parameters

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -17,7 +17,11 @@ var buildCmd = &cobra.Command{
 in the configuration are built. If arguments are provided, they specify the names of the
 images that should be built.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return dockergen.Build(getCommonParams(cmd, args))
+		builds, params, stdout, err := getCommonParams(cmd, args)
+		if err != nil {
+			return err
+		}
+		return dockergen.Build(builds, params, stdout)
 	},
 }
 

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -6,25 +6,35 @@ package cmd
 
 import (
 	"io"
+	"sort"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/nmiyake/dockergen/dockergen"
 )
 
-func getCommonParams(cmd *cobra.Command, args []string) ([]dockergen.BuildParams, dockergen.Params, io.Writer) {
+func getCommonParams(cmd *cobra.Command, args []string) ([]dockergen.BuildParams, dockergen.Params, io.Writer, error) {
+	if len(args) > 0 {
+		args = args[1:]
+	}
+
+	var all []string
 	buildParams := cfg.BuildParams()
 	allParamsMap := make(map[string]dockergen.BuildParams)
 	for _, param := range buildParams {
 		allParamsMap[param.Name] = param
+		all = append(all, param.Name)
 	}
 
 	// if args were specified, run only the requested builds
+	var missing []string
 	if len(args) != 0 {
 		var requestedBuildParams []dockergen.BuildParams
 		for _, curr := range args {
 			param, ok := allParamsMap[curr]
 			if !ok {
+				missing = append(missing, curr)
 				continue
 			}
 			requestedBuildParams = append(requestedBuildParams, param)
@@ -32,5 +42,11 @@ func getCommonParams(cmd *cobra.Command, args []string) ([]dockergen.BuildParams
 		buildParams = requestedBuildParams
 	}
 
-	return buildParams, cfg.ToParams(), cmd.OutOrStdout()
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		sort.Strings(all)
+		return nil, dockergen.Params{}, nil, errors.Errorf("The following specified entries were not defined in configuration: %v\nValid entries: %v", missing, all)
+	}
+
+	return buildParams, cfg.ToParams(), cmd.OutOrStdout(), nil
 }

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -17,7 +17,11 @@ var pushCmd = &cobra.Command{
 images in the configuration are pushed. If arguments are provided, they specify the names of
 the images whose tags should be pushed.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return dockergen.Push(getCommonParams(cmd, args))
+		builds, params, stdout, err := getCommonParams(cmd, args)
+		if err != nil {
+			return err
+		}
+		return dockergen.Push(builds, params, stdout)
 	},
 }
 

--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -17,7 +17,11 @@ var tagCmd = &cobra.Command{
 all of the images in the configuration are printed. If arguments are provided, they
 specify the names of the images for which tags are printed.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return dockergen.Tag(getCommonParams(cmd, args))
+		builds, params, stdout, err := getCommonParams(cmd, args)
+		if err != nil {
+			return err
+		}
+		return dockergen.Tag(builds, params, stdout)
 	},
 }
 


### PR DESCRIPTION
Return an error if unrecognized product is specified and fix
argument handling bug that previously existed.