### PR TITLE
Add "--dry-run" flag and executor

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -17,11 +17,11 @@ var buildCmd = &cobra.Command{
 in the configuration are built. If arguments are provided, they specify the names of the
 images that should be built.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		builds, params, err := getCommonParams(args)
+		executor, builds, params, err := getCommonParams(args)
 		if err != nil {
 			return err
 		}
-		return dockergen.Build(builds, params, cmd.OutOrStdout())
+		return dockergen.Build(executor, builds, params, cmd.OutOrStdout())
 	},
 }
 

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -17,11 +17,11 @@ var pushCmd = &cobra.Command{
 images in the configuration are pushed. If arguments are provided, they specify the names of
 the images whose tags should be pushed.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		builds, params, err := getCommonParams(args)
+		executor, builds, params, err := getCommonParams(args)
 		if err != nil {
 			return err
 		}
-		return dockergen.Push(builds, params, cmd.OutOrStdout())
+		return dockergen.Push(executor, builds, params, cmd.OutOrStdout())
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ import (
 
 var (
 	cfgFile string
+	dryRun  bool
 	cfg     dockergen.Config
 )
 
@@ -56,4 +57,6 @@ func init() {
 		}
 		return nil
 	}
+
+	RootCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "print commands that would be run without running them")
 }

--- a/cmd/tags.go
+++ b/cmd/tags.go
@@ -17,11 +17,11 @@ var tagsCmd = &cobra.Command{
 all of the images in the configuration are printed. If arguments are provided, they
 specify the names of the images for which tags are printed.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		builds, params, err := getCommonParams(args)
+		executor, builds, params, err := getCommonParams(args)
 		if err != nil {
 			return err
 		}
-		return dockergen.Tags(builds, params, cmd.OutOrStdout())
+		return dockergen.Tags(executor, builds, params, cmd.OutOrStdout())
 	},
 }
 

--- a/dockergen/executor.go
+++ b/dockergen/executor.go
@@ -1,0 +1,40 @@
+// Copyright 2017 Nick Miyake. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root
+// for license information.
+
+package dockergen
+
+import (
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+)
+
+type Executor interface {
+	Run(w io.Writer, cmd string, args ...string) error
+}
+
+func NewCmdExecutor() Executor {
+	return &cmdExecutor{}
+}
+
+type cmdExecutor struct{}
+
+func (e *cmdExecutor) Run(w io.Writer, name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = w
+	cmd.Stderr = w
+	return cmd.Run()
+}
+
+func NewPrintCmdExecutor() Executor {
+	return &printCmdExecutor{}
+}
+
+type printCmdExecutor struct{}
+
+func (e *printCmdExecutor) Run(w io.Writer, name string, args ...string) error {
+	_, err := io.WriteString(w, fmt.Sprintln(name, strings.Join(args, " ")))
+	return err
+}


### PR DESCRIPTION
When run with "--dry-run" flag, commands such as "build" and
"publish" print the commands that would be executed without
actually running them.