### PR TITLE
Add --no-deps flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ import (
 var (
 	cfgFile string
 	dryRun  bool
+	noDeps  bool
 	cfg     dockergen.Config
 )
 
@@ -59,4 +60,5 @@ func init() {
 	}
 
 	RootCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "print commands that would be run without running them")
+	RootCmd.PersistentFlags().BoolVar(&noDeps, "no-deps", false, "runs task only for the specified images (do not add dependencies)")
 }

--- a/dockergen/actions.go
+++ b/dockergen/actions.go
@@ -22,19 +22,19 @@ const (
 	defaultBuildID   = "unspecified"
 )
 
-func Build(executor Executor, builds []BuildParams, dockerGenParams Params, stdout io.Writer) error {
-	return runActionLogic(runBuildAction, executor, builds, dockerGenParams, stdout)
+func Build(executors map[string]Executor, builds []BuildParams, dockerGenParams Params, stdout io.Writer) error {
+	return runActionLogic(runBuildAction, executors, builds, dockerGenParams, stdout)
 }
 
-func Push(executor Executor, builds []BuildParams, dockerGenParams Params, stdout io.Writer) error {
-	return runActionLogic(runPushAction, executor, builds, dockerGenParams, stdout)
+func Push(executors map[string]Executor, builds []BuildParams, dockerGenParams Params, stdout io.Writer) error {
+	return runActionLogic(runPushAction, executors, builds, dockerGenParams, stdout)
 }
 
-func Tags(executor Executor, builds []BuildParams, dockerGenParams Params, stdout io.Writer) error {
-	return runActionLogic(runTagAction, executor, builds, dockerGenParams, stdout)
+func Tags(executors map[string]Executor, builds []BuildParams, dockerGenParams Params, stdout io.Writer) error {
+	return runActionLogic(runTagAction, executors, builds, dockerGenParams, stdout)
 }
 
-func runActionLogic(action runActionFunc, executor Executor, builds []BuildParams, dockerGenParams Params, stdout io.Writer) error {
+func runActionLogic(action runActionFunc, executors map[string]Executor, builds []BuildParams, dockerGenParams Params, stdout io.Writer) error {
 	if err := dockerGenParams.Validate(); err != nil {
 		return errors.Wrapf(err, "invalid Docker generator params")
 	}
@@ -64,7 +64,7 @@ func runActionLogic(action runActionFunc, executor Executor, builds []BuildParam
 	tags := make(map[string][][]string)
 	return runInFor(func(idx int, curEvalVarMap map[string]string) error {
 		for _, currBuild := range builds {
-			innerTags, err := runAction(action, executor, currBuild, buildID, tagSuffixTmpl, curEvalVarMap, tags, idx, stdout)
+			innerTags, err := runAction(action, executors[currBuild.Name], currBuild, buildID, tagSuffixTmpl, curEvalVarMap, tags, idx, stdout)
 			if err != nil {
 				return errors.Wrapf(err, "failed to build %s", currBuild.Name)
 			}

--- a/dockergen/executor.go
+++ b/dockergen/executor.go
@@ -38,3 +38,13 @@ func (e *printCmdExecutor) Run(w io.Writer, name string, args ...string) error {
 	_, err := io.WriteString(w, fmt.Sprintln(name, strings.Join(args, " ")))
 	return err
 }
+
+func NoopExecutor() Executor {
+	return &noopExecutor{}
+}
+
+type noopExecutor struct{}
+
+func (e *noopExecutor) Run(w io.Writer, name string, args ...string) error {
+	return nil
+}


### PR DESCRIPTION
When dockergen is run with this flag enabled, dependent images will
be run using the noop executor so that the Docker actions are not
actually run.